### PR TITLE
Codespaces compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.1.6
 
 - "Run Shiny App" now works with Python executable paths that have spaces or other special characters. (#26)
+- "Run Shiny App" now starts a fresh console for each run (and closes the last console it started), so that the app's output is not mixed with the output of previous runs. (#27)
+- Improved compatibility with GitHub Codespaces. (#27)
 
 ## 0.1.5
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,12 @@
         "shiny.python.port": {
           "type": "integer",
           "default": 0,
-          "description": "The port number to listen on when running an app. (Use 0 to choose a random port for each workspace.)"
+          "description": "The port number Shiny should listen on when running an app. (Use 0 to choose a random port.)"
+        },
+        "shiny.python.autoreloadPort": {
+          "type": "integer",
+          "default": 0,
+          "description": "The port number Shiny should use for a supplemental WebSocket channel it uses to support reload-on-save. (Use 0 to choose a random port.)"
         },
         "shiny.python.debugJustMyCode": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@types/vscode": "^1.66.0",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
-    "@vscode/python-extension": "^1.0.5",
     "@vscode/test-electron": "^2.1.3",
     "eslint": "^8.11.0",
     "glob": "^10.3.10",
@@ -103,5 +102,8 @@
   },
   "extensionDependencies": [
     "ms-python.python"
-  ]
+  ],
+  "dependencies": {
+    "@vscode/python-extension": "^1.0.5"
+  }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,0 @@
-export const PYSHINY_EXEC_CMD = "PYSHINY_EXEC_CMD";
-export const PYSHINY_EXEC_SHELL = "PYSHINY_EXEC_SHELL";
-export const TERMINAL_NAME = "Shiny";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,8 @@ import { runApp, debugApp, onDidStartDebugSession } from "./run";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("shiny.python.runApp", () =>
-      runApp(context)
-    ),
-    vscode.commands.registerCommand("shiny.python.debugApp", () =>
-      debugApp(context)
-    )
+    vscode.commands.registerCommand("shiny.python.runApp", runApp),
+    vscode.commands.registerCommand("shiny.python.debugApp", debugApp)
   );
 
   const throttledUpdateContext = new Throttler(2000, updateContext);

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -1,0 +1,122 @@
+import * as http from "http";
+import * as net from "net";
+import { AddressInfo } from "net";
+import * as vscode from "vscode";
+import { getRemoteSafeUrl } from "./extension-api-utils/getRemoteSafeUrl";
+import { retryUntilTimeout } from "./retry-utils";
+
+/**
+ * Tests if a port is open on a host, by trying to connect to it with a TCP
+ * socket.
+ */
+async function isPortOpen(
+  host: string,
+  port: number,
+  timeout: number = 1000
+): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    const client = new net.Socket();
+
+    client.setTimeout(timeout);
+    client.connect(port, host, function () {
+      resolve(true);
+      client.end();
+    });
+
+    client.on("timeout", () => {
+      client.destroy();
+      reject(new Error("Timed out"));
+    });
+
+    client.on("error", (err) => {
+      reject(err);
+    });
+
+    client.on("close", () => {
+      reject(new Error("Connection closed"));
+    });
+  });
+}
+
+/**
+ * Opens a browser for the specified port, once that port is open. Handles
+ * translating http://localhost:<port> into a proxy URL, if necessary.
+ * @param port The port to open the browser for.
+ * @param additionalPorts Additional ports to wait for before opening the
+ * browser.
+ */
+export async function openBrowserWhenReady(
+  port: number,
+  ...additionalPorts: number[]
+): Promise<void> {
+  const portsOpen = [port, ...additionalPorts].map((p) =>
+    retryUntilTimeout(10000, () => isPortOpen("127.0.0.1", p))
+  );
+  const portsOpenResult = await Promise.all(portsOpen);
+  if (portsOpenResult.filter((p) => !p).length > 0) {
+    console.warn("Failed to connect to Shiny app, not launching browser");
+    return;
+  }
+
+  let previewUrl = await getRemoteSafeUrl(port);
+  await openBrowser(previewUrl);
+}
+
+export async function openBrowser(url: string): Promise<void> {
+  // if (process.env["CODESPACES"] === "true") {
+  //   vscode.env.openExternal(vscode.Uri.parse(url));
+  // } else {
+  await vscode.commands.executeCommand("simpleBrowser.api.open", url, {
+    preserveFocus: true,
+    viewColumn: vscode.ViewColumn.Beside,
+  });
+  // }
+}
+
+export async function suggestPort(): Promise<number> {
+  do {
+    const server = http.createServer();
+
+    const p = new Promise<number>((resolve, reject) => {
+      server.on("listening", () =>
+        resolve((server.address() as AddressInfo).port)
+      );
+      server.on("error", reject);
+    }).finally(() => {
+      return closeServer(server);
+    });
+
+    server.listen(0, "127.0.0.1");
+
+    const port = await p;
+
+    if (!UNSAFE_PORTS.includes(port)) {
+      return port;
+    }
+  } while (true);
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.close((errClose) => {
+      if (errClose) {
+        // Don't bother logging, we don't care (e.g. if the server
+        // failed to listen, close() will fail)
+      }
+      // Whether close succeeded or not, we're now ready to continue
+      resolve();
+    });
+  });
+}
+
+// Ports that are considered unsafe by Chrome
+// http://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+// https://github.com/rstudio/shiny/issues/1784
+const UNSAFE_PORTS = [
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79,
+  87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137,
+  139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532,
+  540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723,
+  2049, 3659, 4045, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6697,
+  10080,
+];

--- a/src/port-settings.ts
+++ b/src/port-settings.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import { suggestPort } from "./net-utils";
+
+const transientPorts: Record<string, number | undefined> = {};
+
+export async function getAppPort(reason: "run" | "debug"): Promise<number> {
+  return (
+    // Port can be zero, which means random assignment
+    vscode.workspace.getConfiguration("shiny.python").get("port") ||
+    (await defaultPort(`app_${reason}`))
+  );
+}
+
+export async function getAutoreloadPort(
+  reason: "run" | "debug"
+): Promise<number> {
+  return (
+    // Port can be zero, which means random assignment
+    vscode.workspace.getConfiguration("shiny.python").get("autoreloadPort") ||
+    (await defaultPort(`autoreload_${reason}`))
+  );
+}
+
+async function defaultPort(portCacheKey: string): Promise<number> {
+  // Retrieve most recently used port
+  let port: number = transientPorts[portCacheKey] ?? 0;
+  if (port !== 0) {
+    return port;
+  }
+
+  port = await suggestPort();
+
+  // Save for next time
+  transientPorts[portCacheKey] = port;
+
+  return port;
+}

--- a/src/retry-utils.ts
+++ b/src/retry-utils.ts
@@ -1,12 +1,21 @@
+/**
+ * Repeatedly calls callback until it executes without throwing an error, or
+ * until timeoutMs has passed.
+ * @param timeoutMs Number of milliseconds to wait before giving up.
+ * @param callback The function to call repeatedly.
+ * @returns The return value of the first successful call to the callback
+ * (doesn't have to be truthy, just not erroring); or undefined if the timeout
+ * was reached.
+ */
 export async function retryUntilTimeout<T>(
   timeoutMs: number,
   callback: () => Promise<T>
 ): Promise<T | undefined> {
-  let { result, cancel: cancelResult } = retryUntilCancel(20, callback);
+  const { result, cancel: cancelResult } = retryUntilCancel(20, callback);
 
   let timer: NodeJS.Timeout | undefined;
-  let timeoutPromise = new Promise<undefined>((resolve) => {
-    timer = setTimeout(() => resolve, timeoutMs);
+  const timeoutPromise = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), timeoutMs);
   });
 
   try {
@@ -19,6 +28,16 @@ export async function retryUntilTimeout<T>(
   }
 }
 
+/**
+ * Repeatedly calls callback until it executes without throwing an error, or
+ * until the operation is cancelled.
+ * @param intervalMs Number of milliseconds to wait between retries.
+ * @param callback The function to call repeatedly.
+ * @returns An object with two properties: `result`, a promise that resolves to
+ * the return value of the first successful call to the callback (doesn't have
+ * to be truthy, just not erroring) or rejects with Error("Cancelled") if
+ * cancelled; and `cancel`, a function you can call to stop the retries.
+ */
 export function retryUntilCancel<T>(
   intervalMs: number,
   callback: () => Promise<T>

--- a/src/run.ts
+++ b/src/run.ts
@@ -179,7 +179,10 @@ async function createTerminalAndCloseOthersWithSameName(
 
   const closingTerminals = oldTerminals.map((x) => {
     const p = new Promise<void>((resolve) => {
-      // Resolve when the terminal is closed
+      // Resolve when the terminal is closed. We're working hard to be accurate
+      // BUT empirically it doesn't seem like the old Shiny processes are
+      // actually terminated at the time this promise is resolved, so callers
+      // shouldn't assume that.
       const subscription = vscode.window.onDidCloseTerminal(function sub(term) {
         if (term === x) {
           subscription.dispose();

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -1,8 +1,13 @@
 import * as vscode from "vscode";
-import { PYSHINY_EXEC_SHELL } from "./constants";
 
 type EscapeStyle = "cmd" | "ps" | "sh";
+const PYSHINY_EXEC_SHELL = "PYSHINY_EXEC_SHELL";
 
+/**
+ * Determine the escaping style to use for a terminal.
+ * @param terminal The terminal to determine the escaping style for.
+ * @returns The escaping style to use.
+ */
 function escapeStyle(terminal: vscode.Terminal): EscapeStyle {
   const termEnv =
     (terminal.creationOptions as vscode.TerminalOptions).env || {};
@@ -17,30 +22,46 @@ function escapeStyle(terminal: vscode.Terminal): EscapeStyle {
   }
 }
 
-export function escapeArg(filePath: string, style: EscapeStyle): string {
+/**
+ * Escape a single argument for use in a shell command. Varies behavior
+ * depending on the desired escaping style.
+ * @param arg The arg value to escape.
+ * @param style One of "cmd", "ps", or "sh".
+ * @returns An escaped version of the argument.
+ */
+export function escapeArg(arg: string, style: EscapeStyle): string {
   switch (style) {
     case "cmd":
       // For cmd.exe, double quotes are used to handle spaces, and carets (^) are used to escape special characters.
-      const escaped = filePath.replace(/([()%!^"<>&|])/g, "^$1");
+      const escaped = arg.replace(/([()%!^"<>&|])/g, "^$1");
       return /\s/.test(escaped) ? `"${escaped}"` : escaped;
 
     case "ps":
-      if (!/[ '"`,;(){}|&<>@#[\]]/.test(filePath)) {
-        return filePath;
+      if (!/[ '"`,;(){}|&<>@#[\]]/.test(arg)) {
+        return arg;
       }
       // PowerShell accepts single quotes as literal strings and does not require escaping like cmd.exe.
       // Single quotes in the path itself need to be doubled though.
-      return `'${filePath.replace(/'/g, "''")}'`;
+      return `'${arg.replace(/'/g, "''")}'`;
 
     case "sh":
       // For bash, spaces are escaped with backslashes, and special characters are handled similarly.
-      return filePath.replace(/([\\ !"$`&*()|[\]{};<>?])/g, "\\$1");
+      return arg.replace(/([\\ !"$`&*()|[\]{};<>?])/g, "\\$1");
 
     default:
       throw new Error('Unsupported style. Use "cmd", "ps", or "sh".');
   }
 }
 
+/**
+ *
+ * @param terminal The terminal to escape the command for.
+ * @param exec The command to execute. Can be null if only args are needed (e.g.
+ * if you're adding additional arguments to an existing command line).
+ * @param args Arguments to the command, if any.
+ * @returns The escaped command line. If the terminal is PowerShell, the command
+ * is prefixed with "& ".
+ */
 export function escapeCommandForTerminal(
   terminal: vscode.Terminal,
   exec: string | null,
@@ -59,4 +80,15 @@ export function escapeCommandForTerminal(
   } else {
     return cmd;
   }
+}
+
+/**
+ * Save metadata to the terminal's environment so we can retrieve it later, to
+ * determine how to escape arguments.
+ * @returns A map of env vars to include in the terminal's environment.
+ */
+export function envVarsForShell(): Record<string, string> {
+  return {
+    [PYSHINY_EXEC_SHELL]: vscode.env.shell,
+  };
 }


### PR DESCRIPTION
Really surprisingly difficult to get it working semi-reliably with Codespaces' port forwarding. Also requires https://github.com/posit-dev/py-shiny/pull/1167.

I ended up moving a lot of code around, as run.ts was getting too unwieldy for me to make sense of, much less someone else reviewing it. So the diff doesn't make much sense--I'd just review the new run.ts from the top down.