### PR TITLE
ci: Upload the `.vsix` package to GitHub actions as artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,8 @@ jobs:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
           dryRun: ${{ github.ref_name == 'main' }}
+      - name: Upload extension to Actions Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: shiny-vscode
+          path: "shiny*.vsix"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
       - "v[0-9]*"
     branches:
       - "main"
+  pull_request:
+    branches:
+      - "main"
 
 name: Deploy Extension
 jobs:
@@ -19,13 +22,13 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          dryRun: ${{ github.ref_name == 'main' }}
+          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
-          dryRun: ${{ github.ref_name == 'main' }}
+          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Upload extension to Actions Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,22 +18,17 @@ jobs:
         with:
           node-version: "18.x"
       - run: yarn install --immutable --immutable-cache --check-cache
-      - name: Will publish?
-        run: >
-          echo "dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}"
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          dryRun: true
-          # dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
-          dryRun: true
-          # dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Upload extension to Actions Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,17 +18,22 @@ jobs:
         with:
           node-version: "18.x"
       - run: yarn install --immutable --immutable-cache --check-cache
+      - name: Will publish?
+        run: >
+          echo "dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}"
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+          dryRun: true
+          # dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
-          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
+          dryRun: true
+          # dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
       - name: Upload extension to Actions Artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Adds a step to upload the packaged `.vsix` file to the GitHub action run as an artifact, which makes it easier to download and test the extension.

We could also consider uploading the extension as a release artifact ([an example workflow is outlined here](https://cezarypiatek.github.io/post/develop-vsextension-with-github-actions/#release-workflow)).