### PR TITLE
Remove unnecessary `onCommand` events from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,14 @@
     "url": "https://github.com/rstudio/pyshiny-vscode"
   },
   "engines": {
-    "vscode": "^1.66.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Other"
   ],
   "activationEvents": [
     "onLanguage:python",
-    "onCommand:shiny.python.runApp",
-    "onCommand:shiny.python.debugApp",
-    "onLanguage:r",
-    "onCommand:shiny.r.runApp"
+    "onLanguage:r"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
Fixes #35 by removing `onCommand:*` from `activationEvents`.