### PR TITLE
Improve support for Shiny for R apps that use `ui.R` and friends

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,5 +147,14 @@ function isShinyAppUsername(filename: string, language: string): boolean {
     return true;
   }
 
+  if (language === "r") {
+    return isShinyAppRPart(filename);
+  }
+
   return false;
+}
+
+export function isShinyAppRPart(filename: string): boolean {
+  filename = path.basename(filename);
+  return ["ui.r", "server.r", "global.r"].includes(filename.toLowerCase());
 }


### PR DESCRIPTION
Fixes #38

Detects Shiny apps from files name `ui.R`, `server.R`, `global.R` and passes the directory containing the file to `shiny::runApp()` instead of the file path.

Note that we still require the word "shiny" to appear in the file contents in these cases, so sometimes `server.R` or `global.R` might not activate the extension. Users can still manually activate the "Run Shiny app" command in these cases.