### PR TITLE
feat: Add `shiny.previewType` configuration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The extension now supports Shiny for R apps. (#30)
 - The [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is now a soft dependency and is no longer installed by default with the Shiny for VS Code extension. (#30)
+- Added a new setting, `shiny.previewType`, to control where the Shiny app preview should be opened. (#40)
 
 ## 0.1.6
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
             "Preview using a preview panel inside VS Code",
             "Preview using a Simple Browser inside VS Code",
             "Preview using an external web browser",
-            "Don't automatically show a preview after render"
+            "Don't automatically launch the app after starting"
           ]
         },
         "shiny.python.port": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,24 @@
     "configuration": {
       "title": "Shiny",
       "properties": {
+        "shiny.previewType": {
+          "scope": "window",
+          "type": "string",
+          "description": "Where should the Shiny app preview open?",
+          "enum": [
+            "internal",
+            "simpleBrowser",
+            "external",
+            "none"
+          ],
+          "default": "internal",
+          "markdownEnumDescriptions": [
+            "Preview using a preview panel inside VS Code",
+            "Preview using a Simple Browser inside VS Code",
+            "Preview using an external web browser",
+            "Don't automatically show a preview after render"
+          ]
+        },
         "shiny.python.port": {
           "type": "integer",
           "default": 0,

--- a/src/extension-api-utils/extensionHostPreview.ts
+++ b/src/extension-api-utils/extensionHostPreview.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+
+declare const globalThis: {
+    [key: string]: any;
+};
+
+export interface HostWebviewPanel extends vscode.Disposable {
+    readonly webview: vscode.Webview;
+    readonly visible: boolean;
+    reveal(viewColumn?: vscode.ViewColumn, preserveFocus?: boolean): void;
+    readonly onDidChangeViewState: vscode.Event<any>;
+    readonly onDidDispose: vscode.Event<void>;
+}
+
+export function getExtensionHostPreview(): void | ((url: string) => HostWebviewPanel) {
+    if (
+        "acquirePositronApi" in globalThis &&
+        typeof globalThis.acquirePositronApi === "function"
+    ) {
+        const pst = globalThis.acquirePositronApi();
+        if (!pst) { return; }
+        return (url: string) => pst.window.previewUrl(vscode.Uri.parse(url));
+    }
+}


### PR DESCRIPTION
Adds a new setting allowing users to choose whether the app should be opened internally, externally, or if no preview should be opened at all.